### PR TITLE
removing mocks and cmd dirs from testing

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,7 +20,7 @@ docker run -p 5432:5432 --name PostgresStoreTest -e POSTGRES_PASSWORD=mysecretpa
 docker run -p 27017:27017 --name MongoStoreTest -d mongo:4.2.8 >/dev/null || true
 docker run -p 5984:5984 -d --name CouchDBStoreTest couchdb:2.3.1 >/dev/null || true
 
-for d in $(go list ./pkg/... | grep -v vendor); do
+for d in $(go list ./pkg/... | grep -v vendor | grep -v mocks | grep -v cmd); do
   go test -race -coverprofile=profile.out -covermode=atomic $d
   if [ -f profile.out ]; then
     cat profile.out >>coverage.txt


### PR DESCRIPTION
Explicitly removing mocks, and cmd directories.

Testing cmd doesn't provide much value other than test coverage. 
They don't contain "core" business logic, and if they become broken, it will be a deploy time failure, we think this is a reasonable tradeoff vs the hoop-jumping required to get 100% test coverage.