### PR TITLE
Build and push docker image with semantic tags on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Build
-      run: make build
+      run: make
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,45 +1,8 @@
-name: Build
-
+name: Publish Docker image
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-
+  release:
+    types: [published]
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-18.04
-    container: scoir/canis-build:latest
-    services:
-      rabbitmq:
-        image: rabbitmq
-        ports:
-          - 5672:5672
-      mongodb:
-        image: mongo:4.2.8
-        ports:
-          - 27017:27017
-    steps:
-    - name: Set up Go 1.14
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.14
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Test
-      run: make test
-      env:
-        RABBITMQ_HOST: rabbitmq
-        MONGODB_HOST: mongodb
-
-    - name: Upload coverage to Codecov
-      timeout-minutes: 5
-      run: curl -s https://codecov.io/bash | bash
-
   publish:
     name: Build Docker Image
     runs-on: ubuntu-18.04
@@ -57,6 +20,22 @@ jobs:
 
     - name: Build
       run: make build
+
+    - name: Prepare
+      id: prep
+      run: |
+        DOCKER_IMAGE=canislabs/canis
+        VERSION=${GITHUB_REF#refs/tags/}
+
+        TAGS="${DOCKER_IMAGE}:${VERSION}"
+        if echo $VERSION | grep -Eq  '^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'; then
+          MINOR=${VERSION%.*}
+          MAJOR=${MINOR%.*}
+          TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+        fi
+        echo ::set-output name=version::${VERSION}
+        echo ::set-output name=tags::${TAGS}
+        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -76,4 +55,5 @@ jobs:
         context: .
         file: ./docker/canis/Dockerfile
         platforms: linux/amd64
-
+        push: true
+        tags: ${{ steps.prep.outputs.tags }}

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ canis-docker-publish: canis-docker
 	@docker tag canis/canis registry.hyades.svc.cluster.local:5000/canis
 	@docker push registry.hyades.svc.cluster.local:5000/canis
 
+canis-build-docker:
+	@echo "building canis build docker image..."
+	@docker build -f ./docker/build/Dockerfile -t scoir/canis-build:latest .
+
+
 all-pb: canis-common-pb canis-apiserver-pb canis-didcomm-doorman-pb canis-didcomm-issuer-pb canis-didcomm-verifier-pb canis-didcomm-lb-pb
 
 canis-common-pb: pkg/proto/canis-common.pb.go

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -3,7 +3,16 @@ FROM scoir/indy-libs:latest
 RUN apt-get -y update
 RUN apt-get -y upgrade
 
-RUN apt-get install -y build-essential wget git curl protobuf-compiler unzip
+RUN apt-get install -y build-essential wget git curl protobuf-compiler unzip apt-transport-https ca-certificates gnupg-agent software-properties-common
+
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+RUN add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) \
+       stable"
+
+RUN apt-get update
+RUN apt-get install -y docker-ce docker-ce-cli containerd.io
 
 RUN wget https://dl.google.com/go/go1.14.6.linux-amd64.tar.gz -q -P /tmp -nH
 RUN tar -xzf /tmp/go1.14.6.linux-amd64.tar.gz -C /tmp

--- a/docker/canis/Dockerfile
+++ b/docker/canis/Dockerfile
@@ -1,6 +1,5 @@
 FROM scoir/indy-libs:latest
 
-RUN apt-get install -y ca-certificates
 RUN apt-get update
 
 COPY ./bin/canis-apiserver /usr/local/bin/canis-apiserver


### PR DESCRIPTION
This PR builds an image on each PR build to ensure it isn't broken.

Also build and deploy image to Docker Hub with proper semantic version (eg: v0, v0.1, v0.1.0, latest) for every release.

Closes #83 