### PR TITLE
adds support for an apikey for the swagger UI

### DIFF
--- a/pkg/proto/canis-apiserver.proto
+++ b/pkg/proto/canis-apiserver.proto
@@ -11,8 +11,27 @@ option go_package = "apiserver/api";
 option (grpc.gateway.protoc_gen_swagger.options.openapiv2_swagger) = {
 	info: {
 		title: "Canis Admin API";
-version:"0.0.2"
-}
+    version:"0.0.2";
+    license: {
+      name: "Apache 2.0";
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html";
+    };
+	};
+  security_definitions: {
+    security: {
+      key: "ApiKey";
+      value: {
+        type: TYPE_API_KEY;
+      }
+    }
+  }
+  security: {
+    security_requirement: {
+      key: "ApiKey";
+      value: {
+      };
+    }
+  };
 };
 
 


### PR DESCRIPTION
need to add support for actually verifying an API key, but throwing this out for good measure