### PR TITLE
Update check-license script

### DIFF
--- a/scripts/check_license.sh
+++ b/scripts/check_license.sh
@@ -11,7 +11,7 @@ function filterExcludedFiles {
   CHECK=`echo "$CHECK" | grep -v .png$ | grep -v .rst$ | grep -v ^.git/ \
   | grep -v .pem$ | grep -v .block$ | grep -v .tx$ | grep -v ^LICENSE$ | grep -v _sk$ \
   | grep -v .key$ | grep -v .crt$ | grep -v \\.gen.go$ | grep -v \\.json$ | grep -v Gopkg.lock$ \
-  | grep -v .md$ | grep -v ^vendor/ | grep -v ^build/ | grep -v .pb.go$ | grep -v ci.properties$ \
+  | grep -v .md$ | grep -v ^vendor/ | grep -v ^build/ | grep -v .pb.gw.go | grep -v .pb.go$ | grep -v ci.properties$ \
   | grep -v go.sum$ | grep -v gomocks | sort -u`
 }
 


### PR DESCRIPTION
Use the following template for your PR (make sure you follow our
[guidelines](CONTRIBUTING.md#pull-request):

**Title:**
Fix error when running check-license

**Description:**
Trying to run make after cloning the repo resulted in the following error:
```
Running scripts/check_license.sh                                                      
Examining last commit changes                                                         
The following files are missing SPDX-License-Identifier headers:                      
pkg/apiserver/api/protogen/canis-apiserver.pb.gw.go                                   
pkg/proto/canis-apiserver.proto                                                       
static/swaggerui/swagger-ui.css                                                       
                                                                                      
Please replace the Apache license header comment text with:                           
SPDX-License-Identifier: Apache-2.0                                                   
                                                                                      
Checking committed files for traditional Apache License headers ...                   
The following files are missing traditional Apache 2.0 headers:                       
pkg/apiserver/api/protogen/canis-apiserver.pb.gw.go                                   
static/swaggerui/swagger-ui.css                                                       
Fatal Error - All files must have a license header                                    
make: *** [Makefile:40: license] Error 1 
```
At first I thought of including the license in the files, since they started with a do not edit comment I just updated the check-license script

I didn't change the other 2 files (pkg/proto/canis-apiserver.proto and static/swaggerui/swagger-ui.css) as make worked just by changing the other one but I can change them if necessary

Summary:
Update check-license script to also exclude files ending with .pb.gw.go